### PR TITLE
Added Dockerfile to easily run BliSSART CLI.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:12.04
+
+# Installing depedencies.
+RUN apt-get update -y
+RUN apt-get install -y git make g++ autoconf libtool libpoco-dev libfftw3-dev libsdl-sound1.2-dev libatlas-base-dev qt4-dev-tools
+
+# Creating our work dir.
+RUN mkdir ~/src
+WORKDIR "root/src"
+
+# Installing openBliSSART
+RUN git clone https://github.com/openBliSSART/openBliSSART
+WORKDIR "./openBliSSART"
+RUN ./bootstrap.sh
+RUN ./configure --prefix=${HOME}/blissart
+RUN make
+RUN make install
+
+# Setting env.
+RUN sh -c "echo ${HOME}/blissart/lib > /etc/ld.so.conf.d/blissart.conf"
+RUN ldconfig
+
+# Setting dir for when user logs into the container.
+WORKDIR "/root/blissart/bin"
+CMD /bin/bash

--- a/INSTALL
+++ b/INSTALL
@@ -35,7 +35,17 @@ In case of installation problems or application crashes, please consult this
 section.
 
 
-0. Installation for the Impatient Linux User
+0.1. (Simplest Way) Running with Docker
+
+If you would like to run this application with Docker, simply download the Dockerfile from the root of this project and run the following:
+
+$ docker built -t blissart .
+$ docker run -it blissart
+$ ls
+
+You won't be able to run the browser GUI, but you will be able to use the CLI included with blissart. 
+
+0.2. Installation for the Impatient Linux User
 
 Given that you have recent versions of FFTW3, SDL, SDL_sound, Poco, Qt, and
 ATLAS (and the corresponding "developer" packages, or whatever your

--- a/INSTALL
+++ b/INSTALL
@@ -39,7 +39,7 @@ section.
 
 If you would like to run this application with Docker, simply download the Dockerfile from the root of this project and run the following:
 
-$ docker built -t blissart .
+$ docker build -t blissart .
 $ docker run -it blissart
 $ ls
 


### PR DESCRIPTION
The project's installation process is overly obscured, so this is a quick addition to allow running the software without any major headaches. Download and install [Docker](https://www.docker.com/), and then simply download the [`Dockerfile`](https://github.com/synchronizing/openBliSSART/blob/master/Dockerfile) in this pull request, and run the following in the same directory as the `Dockerfile`:

```
docker build -t blissart .
docker run -it blissart
```

From there you will be able to do `ls` and start using all the CLI tools that comes with BliSSART. Unfortunately, since Qt was utilized in the original project, browser GUI is not supported. If browser GUI is something you require, I recommend creating a new virtual machine with **specifically** Ubuntu version 12.04 (any newer version will not work) and then follow the lazy installation on the `INSTALL` file after installing basic dependencies via `apt-get` (same as the one in the Dockerfile). 

Documentation on how to separate your audio files via the CLI can be found in the original openBliSSART manual (**2.1.3 Command Line Separation**): http://openblissart.github.io/openBliSSART/manual.pdf